### PR TITLE
DI 컨테이너 구현하기

### DIFF
--- a/di/src/test/java/nextstep/study/di/stage3/context/DIContainer.java
+++ b/di/src/test/java/nextstep/study/di/stage3/context/DIContainer.java
@@ -65,7 +65,8 @@ class DIContainer {
 
 
                 // field.getDeclaringClass() : 필드를 선언한 클래스의 타입임. 필드의 타입 아님!!
-                // field.getType()가 필드의 타입이다.
+                // field.getType()가 필드의 타입이다.이
+                // 인터페이스타입.isAssignableFrom(구현타입)은 구현타입이 인터페이스의 구현타입인지 확인 가능하다.
                 Object bean = beans.stream()
                         .filter(b -> field.getType().isAssignableFrom(b.getClass()))
                         .findAny()
@@ -77,7 +78,7 @@ class DIContainer {
                     continue;
                 }
 
-                // 모든 과정을 넘어왔다면 빈을 주입할 수 있다. 축하한다!
+                // 모든 과정을 넘어왔다면 빈을 주입할 수 있다.
                 try {
                     field.set(instance, bean);
                 } catch (IllegalAccessException e) {

--- a/di/src/test/java/nextstep/study/di/stage3/context/DIContainer.java
+++ b/di/src/test/java/nextstep/study/di/stage3/context/DIContainer.java
@@ -1,6 +1,15 @@
 package nextstep.study.di.stage3.context;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
+
+import javassist.tools.reflect.Reflection;
 
 /**
  * 스프링의 BeanFactory, ApplicationContext에 해당되는 클래스
@@ -10,11 +19,80 @@ class DIContainer {
     private final Set<Object> beans;
 
     public DIContainer(final Set<Class<?>> classes) {
-        this.beans = Set.of();
+        this.beans = new HashSet<>();
+        initialize(classes);
+    }
+
+    private void initialize(Set<Class<?>> classes) {
+        for (Class<?> clazz : classes) {
+            try {
+                Constructor<?> constructor = clazz.getDeclaredConstructor();
+                constructor.setAccessible(true); // private 생성자에 대해서도 접근을 열어주어야 한다.
+                beans.add(constructor.newInstance());
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        for (Class<?> clazz : classes) {
+            Object instance = getBean(clazz);
+            Field[] declaredFields = clazz.getDeclaredFields();
+
+            for (Field field : declaredFields) {
+                field.setAccessible(true);
+
+                // static final이라면 빈 주입하지 않음.
+                int modifiers = field.getModifiers();
+
+                if (Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers)) {
+                    continue;
+                }
+
+                Object fieldValue = null;
+
+                // 기존에 이미 설정된 값이 있다면 주입하지 않는다.
+                try {
+                    fieldValue = field.get(instance);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+
+                if (fieldValue != null) {
+                    continue;
+                }
+
+
+                // field.getDeclaringClass() : 필드를 선언한 클래스의 타입임. 필드의 타입 아님!!
+                // field.getType()가 필드의 타입이다.
+                Object bean = beans.stream()
+                        .filter(b -> field.getType().isAssignableFrom(b.getClass()))
+                        .findAny()
+                        .orElse(null);
+
+                System.out.println(field.getType() + "->" + bean);
+
+                if (bean == null) {
+                    continue;
+                }
+
+                // 모든 과정을 넘어왔다면 빈을 주입할 수 있다. 축하한다!
+                try {
+                    field.set(instance, bean);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")
     public <T> T getBean(final Class<T> aClass) {
-        return null;
+
+        return (T) beans.stream()
+                .filter(bean -> bean.getClass() == aClass)
+                .findAny()
+                .orElseThrow(() -> new NoSuchElementException("없습니다."));
     }
 }

--- a/di/src/test/java/nextstep/study/di/stage4/annotations/ClassPathScanner.java
+++ b/di/src/test/java/nextstep/study/di/stage4/annotations/ClassPathScanner.java
@@ -2,9 +2,22 @@ package nextstep.study.di.stage4.annotations;
 
 import java.util.Set;
 
+import org.assertj.core.internal.bytebuddy.matcher.SubTypeMatcher;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.FilterBuilder;
+
 public class ClassPathScanner {
 
     public static Set<Class<?>> getAllClassesInPackage(final String packageName) {
-        return null;
+        // Object.class의 서브타입으로 조회 -> 모든 클래스가 조회된다.
+        // 기본적으로 Object.class의 서브타입 조회가 되지 않는다. 따라서 Scanners 커스터마이징이 필요하다.
+        // 기본 필터를 사용하지 않고 텅 빈 필터를 사용하도록 한다.
+
+        Scanners customScanner = Scanners.SubTypes.filterResultsBy(new FilterBuilder());
+        Reflections reflections = new Reflections(packageName, customScanner);
+
+        return reflections.getSubTypesOf(Object.class);
     }
 }

--- a/di/src/test/java/nextstep/study/di/stage4/annotations/DIContainer.java
+++ b/di/src/test/java/nextstep/study/di/stage4/annotations/DIContainer.java
@@ -5,7 +5,8 @@ import java.util.Set;
 /**
  * 스프링의 BeanFactory, ApplicationContext에 해당되는 클래스
  */
-class DIContainer {
+class
+DIContainer {
 
     private final Set<Object> beans;
 

--- a/di/src/test/java/nextstep/study/di/stage4/annotations/DIContainer.java
+++ b/di/src/test/java/nextstep/study/di/stage4/annotations/DIContainer.java
@@ -1,6 +1,14 @@
 package nextstep.study.di.stage4.annotations;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 스프링의 BeanFactory, ApplicationContext에 해당되는 클래스
@@ -11,15 +19,101 @@ DIContainer {
     private final Set<Object> beans;
 
     public DIContainer(final Set<Class<?>> classes) {
-        this.beans = Set.of();
+        this.beans = new HashSet<>();
+        initialize(classes);
     }
 
-    public static DIContainer createContainerForPackage(final String rootPackageName) {
-        return null;
+    private void initialize(Set<Class<?>> classes) {
+        for (Class<?> clazz : classes) {
+            try {
+                Constructor<?> constructor = clazz.getDeclaredConstructor();
+                constructor.setAccessible(true); // private 생성자에 대해서도 접근을 열어주어야 한다.
+                beans.add(constructor.newInstance());
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        for (Class<?> clazz : classes) {
+            Object instance = getBean(clazz);
+            Field[] declaredFields = clazz.getDeclaredFields();
+
+            for (Field field : declaredFields) {
+                field.setAccessible(true);
+
+                // inject 어노테이션이 존재하지 않다면 애초에 주입이 필요가 없다.
+                if (!field.isAnnotationPresent(Inject.class)) {
+                    continue;
+                }
+
+                // static final이라면 빈 주입하지 않음.
+                int modifiers = field.getModifiers();
+
+                if (Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers)) {
+                    continue;
+                }
+
+                Object fieldValue = null;
+
+                // 기존에 이미 설정된 값이 있다면 주입하지 않는다.
+                try {
+                    fieldValue = field.get(instance);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+
+                if (fieldValue != null) {
+                    continue;
+                }
+
+
+                // field.getDeclaringClass() : 필드를 선언한 클래스의 타입임. 필드의 타입 아님!!
+                // field.getType()가 필드의 타입이다.이
+                // 인터페이스타입.isAssignableFrom(구현타입)은 구현타입이 인터페이스의 구현타입인지 확인 가능하다.
+                Object bean = beans.stream()
+                        .filter(b -> field.getType().isAssignableFrom(b.getClass()))
+                        .findAny()
+                        .orElse(null);
+
+                System.out.println(field.getType() + "->" + bean);
+
+                if (bean == null) {
+                    continue;
+                }
+
+                // 모든 과정을 넘어왔다면 빈을 주입할 수 있다.
+                try {
+                    field.set(instance, bean);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")
     public <T> T getBean(final Class<T> aClass) {
-        return null;
+        return (T) beans.stream()
+                .filter(bean -> bean.getClass() == aClass)
+                .findAny()
+                .orElseThrow(() -> new NoSuchElementException("없습니다."));
+    }
+    public static DIContainer createContainerForPackage(final String rootPackageName) {
+        Set<Class<?>> classes = ClassPathScanner.getAllClassesInPackage(rootPackageName);
+        System.out.println(classes);
+        // 개선점 1. 어노테이션 타입도 리스트로 관리한다면 더 좋을 거 같다.
+        Set<Class<?>> classesWithAnnotation = classes.stream()
+                .filter(clazz -> hasAnnotation(clazz, Repository.class) || hasAnnotation(clazz, Service.class))
+                .collect(Collectors.toSet());
+
+        System.out.println(classesWithAnnotation);
+
+        return new DIContainer(classesWithAnnotation);
+    }
+
+    private static boolean hasAnnotation(Class<?> clazz, Class<? extends Annotation> annotation) {
+        return clazz.getDeclaredAnnotation(annotation) != null;
     }
 }

--- a/di/src/test/java/nextstep/study/di/stage4/annotations/Inject.java
+++ b/di/src/test/java/nextstep/study/di/stage4/annotations/Inject.java
@@ -9,3 +9,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Inject {
 }
+
+// spring의 Autowired
+// 자바 표준에서는 Inject라는 어노테이션으로 주입해 준다.


### PR DESCRIPTION
전체적인 구현 로직은 다음과 같습니다.

1. 기본 생성자로 빈 생성
2. DI 컨테이너에 타입에 해당하는 인스턴스가 존재하다면 주입

전체적으로 구현이 생각보다 많이 어려웠던 것 같습니다.. 처음에 @Inject 어노테이션을 사용할 때는 더 직관적이라 구현이 용이했으나, 어노테이션을 붙이지 않았을 때는 모든 필드에 대해 빈으로 등록되어있는지 체크해 주어야 해서 복잡했습니다.

### 제어의 역전
- 기존 방식에서는 객체가 능동적으로 자기가 사용할 클래스를 생성하고, 직접 객체를 생성했습니다.
- 제어의 역전이란 모든 제어 권한을 자신이 아닌 다른 대상에게 위임합니다.
 
### 추가적으로 학습한 내용들
1. 리플렉션으로 객체 만들 때, 생성자에 대해서도 private를 열어 주어야 한다.
```java
Constructor<?> constructor = clazz.getDeclaredConstructor();
constructor.setAccessible(true); // private 생성자에 대해서도 접근을 열어주어야 한다.
beans.add(constructor.newInstance());
```

2. static final 체크 로직은 다음과 같다.
```java
// static final이라면 빈 주입하지 않음.
int modifiers = field.getModifiers();

if (Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers)) {
    continue;
}
```

3. 인스턴스의 필드값을 가져오는 방법
```java
Object fieldValue = null;

// 기존에 이미 설정된 값이 있다면 주입하지 않는다.
try {
    fieldValue = field.get(instance);
} catch (IllegalAccessException e) {
    throw new RuntimeException(e);
}
```

4. 인스턴스가 인터페이스의 구현체인지 확인하는 방법
```java
// field.getDeclaringClass() : 필드를 선언한 클래스의 타입임. 필드의 타입 아님!!
// field.getType()가 필드의 타입이다.이
// 인터페이스타입.isAssignableFrom(구현타입)은 구현타입이 인터페이스의 구현타입인지 확인 가능하다.
Object bean = beans.stream()
        .filter(b -> field.getType().isAssignableFrom(b.getClass()))
        .findAny()
        .orElse(null);

System.out.println(field.getType() + "->" + bean);

if (bean == null) {
    continue;
}
```